### PR TITLE
Raise `ValueError` for invalid paths

### DIFF
--- a/flaris/audio.py
+++ b/flaris/audio.py
@@ -142,6 +142,11 @@ class AudioSource:
             path: Path to an audio file.
             loop: If true, then loop the audio indefinitely.
         """
+        if not os.path.exists(path):
+            raise ValueError(
+                f"Expected to find an audio file at \"{path}\", but a file "
+                f"does not exist at that path.")
+
         _SOURCES.append(self)
 
         audio_file = AudioFile(path)

--- a/flaris/rendering/font.py
+++ b/flaris/rendering/font.py
@@ -1,4 +1,5 @@
 """Implements the `Font` class."""
+import os
 from typing import Dict
 
 import freetype
@@ -27,6 +28,11 @@ class Font:  # pylint: disable=too-few-public-methods
             path: Path to a font file relative to the assets directory.
             size: The font size in points.
         """
+        if not os.path.exists(path):
+            raise ValueError(
+                f"Expected to find a font file at \"{path}\", but a file does "
+                f"not exist at that path.")
+
         self.path = path
         self.size = size
         self._characters = {}

--- a/flaris/rendering/icon.py
+++ b/flaris/rendering/icon.py
@@ -1,4 +1,6 @@
 """Implements the `Icon` class."""
+import os
+
 from PIL import Image
 
 __all__ = ["Icon"]
@@ -36,6 +38,11 @@ class Icon:  # pylint: disable=too-few-public-methods
             path: A path to an image. The path should be relative to the assets
                 directory.
         """
+        if not os.path.exists(path):
+            raise ValueError(
+                f"Expected to find an image at \"{path}\", but a file does not "
+                f"exist at that path.")
+
         self.path = path
         image = Image.open(path)
         self.images = [image.resize((size, size)) for size in self.sizes]

--- a/flaris/rendering/renderers/sprite.py
+++ b/flaris/rendering/renderers/sprite.py
@@ -54,8 +54,7 @@ class SpriteRenderer:  # pylint: disable=too-few-public-methods
         vertices = np.array([
             0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0
-        ],
-                            dtype=np.float32)
+        ], dtype=np.float32)
 
         self.shader = shader
 

--- a/flaris/rendering/renderers/sprite.py
+++ b/flaris/rendering/renderers/sprite.py
@@ -54,7 +54,8 @@ class SpriteRenderer:  # pylint: disable=too-few-public-methods
         vertices = np.array([
             0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0
-        ], dtype=np.float32)
+        ],
+                            dtype=np.float32)
 
         self.shader = shader
 

--- a/flaris/rendering/shader.py
+++ b/flaris/rendering/shader.py
@@ -29,6 +29,15 @@ class Shader:  # pylint: disable=too-few-public-methods
             fragment: Path to the fragment shader relative to the assets
                 directory.
         """
+        if not os.path.exists(vertex):
+            raise ValueError(
+                f"Expected to find a vertex shader at \"{vertex}\", but a file "
+                f"does not exist at that path.")
+        if not os.path.exists(fragment):
+            raise ValueError(
+                f"Expected to find a fragment shader at \"{fragment}\", but a "
+                f"file does not exist at that path.")
+
         self.vertex_path = vertex
         with open(self.vertex_path) as file:
             self.vertex_source = file.read()

--- a/test/.pylintrc
+++ b/test/.pylintrc
@@ -1,3 +1,6 @@
 [MESSAGES CONTROL]
 
-disable=invalid-name,no-self-use,missing-function-docstring, fixme
+disable=invalid-name,
+        no-self-use,
+        missing-function-docstring,
+        too-few-public-methods

--- a/test/unit/flaris/rendering/test_font.py
+++ b/test/unit/flaris/rendering/test_font.py
@@ -1,0 +1,12 @@
+"""Unit tests for the `flaris.rendering.font` module."""
+import pytest
+
+from flaris.rendering import Font
+
+
+class TestFont:
+    """Unit tests for the `Font` class."""
+
+    def testInit_InvalidPath_RaisesValueError(self):
+        with pytest.raises(ValueError):
+            Font("some-non-existant-image.png")

--- a/test/unit/flaris/rendering/test_icon.py
+++ b/test/unit/flaris/rendering/test_icon.py
@@ -1,4 +1,6 @@
 """Unit tests for the flaris.rendering.icon module."""
+import pytest
+
 from flaris.rendering import Icon
 
 
@@ -9,6 +11,10 @@ class TestIcon:
         icon = Icon("textures/icon.png")
         for image, size in zip(icon.images, icon.sizes):
             assert image.height == size and image.width == size
+
+    def testInit_InvalidPath_RaisesValueError(self):
+        with pytest.raises(ValueError):
+            Icon("some-non-existant-icon.otf")
 
     def testRepr(self):
         icon = Icon("textures/icon.png")

--- a/test/unit/flaris/rendering/test_shader.py
+++ b/test/unit/flaris/rendering/test_shader.py
@@ -1,0 +1,13 @@
+"""Unit tests for the `flaris.rendering.shader` module."""
+import pytest
+
+from flaris.rendering import Shader
+
+
+class TestShader:
+    """Unit tests for `Shader` class."""
+
+    def testInit_InvalidPath_RaisesValueError(self):
+        with pytest.raises(ValueError):
+            Shader("some-non-existant-vertex-shader.glsl",
+                   "some-non-existant-fragment-shader.glsl")

--- a/test/unit/flaris/rendering/test_texture.py
+++ b/test/unit/flaris/rendering/test_texture.py
@@ -1,7 +1,7 @@
 """Unit tests for flaris.rendering.texture."""
 
 
-class TestTexture:  # pylint: disable=too-few-public-methods
+class TestTexture:
     """Unit tests for flaris.rendering.texture."""
 
     def testRepr(self):

--- a/test/unit/flaris/rendering/test_window.py
+++ b/test/unit/flaris/rendering/test_window.py
@@ -1,7 +1,7 @@
 """Unit tests for flaris.rendering.window."""
 
 
-class TestWindow:  # pylint: disable=too-few-public-methods
+class TestWindow:
     """Unit tests for flaris.rendering.window.Window."""
 
     def testInit(self):

--- a/test/unit/flaris/test_audio.py
+++ b/test/unit/flaris/test_audio.py
@@ -1,0 +1,12 @@
+"""Unit tests for the `flaris.audio` module."""
+import pytest
+
+from flaris.audio import AudioSource
+
+
+class TestAudioSource:
+    """Unit tests for `AudioSource` class."""
+
+    def testInit_InvalidPath_RaisesValueError(self):
+        with pytest.raises(ValueError):
+            AudioSource("some-non-existant-sound.mp3")


### PR DESCRIPTION
Fixes #22 

Additions:
* `Font`, `Shader`, `Icon`, and `AudioSource` now raise `ValueError`s if a non-existant path is supplied